### PR TITLE
fix: bucket&object name limit

### DIFF
--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -56,13 +56,13 @@ func NewStartCmd(cmdCfg *parsecmdtypes.Config) *cobra.Command {
 				}
 			}
 
-			return startParsing(ctx)
+			return Parsing(ctx)
 		},
 	}
 }
 
-// startParsing represents the function that should be called when the parse command is executed
-func startParsing(ctx *parser.Context) error {
+// Parsing represents the function that should be called when the parse command is executed
+func Parsing(ctx *parser.Context) error {
 	// Get the config
 	cfg := config.Cfg.Parser
 	log.StartHeight.Add(float64(cfg.StartHeight))

--- a/models/bucket.go
+++ b/models/bucket.go
@@ -6,7 +6,7 @@ type Bucket struct {
 	ID uint64 `gorm:"column:id;primaryKey"`
 
 	BucketID         common.Hash    `gorm:"column:bucket_id;type:BINARY(32);uniqueIndex:idx_bucket_id"`
-	BucketName       string         `gorm:"column:bucket_name;type:varchar(63);uniqueIndex:idx_bucket_name"` // BucketName length between 3 and 63
+	BucketName       string         `gorm:"column:bucket_name;type:varchar(64);uniqueIndex:idx_bucket_name"` // BucketName length between 3 and 63
 	OwnerAddress     common.Address `gorm:"column:owner_address;type:BINARY(20);index:idx_owner"`            // OwnerAddress bucket creator
 	PaymentAddress   common.Address `gorm:"column:payment_address;type:BINARY(20)"`
 	PrimarySpAddress common.Address `gorm:"column:primary_sp_address;type:BINARY(20)"`

--- a/models/object.go
+++ b/models/object.go
@@ -10,9 +10,9 @@ type Object struct {
 	ID uint64 `gorm:"column:id;primaryKey"`
 
 	BucketID   common.Hash `gorm:"column:bucket_id;type:BINARY(32);index:idx_bucket_id"`
-	BucketName string      `gorm:"column:bucket_name;type:varchar(63)"`
+	BucketName string      `gorm:"column:bucket_name;type:varchar(64)"`
 	ObjectID   common.Hash `gorm:"column:object_id;type:BINARY(32);uniqueIndex:idx_object_id"`
-	ObjectName string      `gorm:"column:object_name;type:varchar"`
+	ObjectName string      `gorm:"column:object_name;type:varchar(1024)"`
 
 	CreatorAddress       common.Address `gorm:"column:creator_address;type:BINARY(20)"`
 	OwnerAddress         common.Address `gorm:"column:owner_address;type:BINARY(20);index:idx_owner"`

--- a/models/object.go
+++ b/models/object.go
@@ -12,7 +12,7 @@ type Object struct {
 	BucketID   common.Hash `gorm:"column:bucket_id;type:BINARY(32);index:idx_bucket_id"`
 	BucketName string      `gorm:"column:bucket_name;type:varchar(63)"`
 	ObjectID   common.Hash `gorm:"column:object_id;type:BINARY(32);uniqueIndex:idx_object_id"`
-	ObjectName string      `gorm:"column:object_name;type:varchar(63)"`
+	ObjectName string      `gorm:"column:object_name;type:varchar"`
 
 	CreatorAddress       common.Address `gorm:"column:creator_address;type:BINARY(20)"`
 	OwnerAddress         common.Address `gorm:"column:owner_address;type:BINARY(20);index:idx_owner"`


### PR DESCRIPTION
### Changes

1. fix: bucket&object name limit (refer https://github.com/bnb-chain/greenfield/blob/master/types/s3util/s3util.go)